### PR TITLE
[GH-9] - Fix broken GitHub links in README and package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.1] - 2025-11-07
+- Fixed broken GitHub links in `README.md`
+- Updated Marketplace and CI badge URLs to point to correct repositories
+
+---
+
 ## [1.0.0] - 2025-11-07
 - Initial release  
 - Added `convertToFolder.convert` command  

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also run it from the Command Palette (`Ctrl+Shift+P` / `⇧⌘P`).
 
 **From Marketplace:**
 ```bash
-ext install swisstool-io.convert-to-folder
+ext install swisstool.convert-to-folder
 ````
 
 **From source:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "convert-to-folder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "convert-to-folder",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "convert-to-folder",
   "displayName": "Convert to Folder",
   "description": "Convert extension-less files into folders with a single click",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "SwissTool",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SwissTool-io/convert-to-folder"
+    "url": "https://github.com/SwissTool-io/vscode-convert-to-folder"
   },
   "bugs": {
-    "url": "https://github.com/SwissTool-io/convert-to-folder/issues"
+    "url": "https://github.com/SwissTool-io/vscode-convert-to-folder/issues"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
#### **Summary**

This PR fixes broken GitHub and Marketplace links in the `README.md` and `package.json` file.

#### **Checklist**

* [x] Meets all acceptance criteria from issue  https://github.com/swisstool-io/vscode-convert-to-folder/issues/9
* [x] Verified all links resolve correctly on GitHub and VS Code Marketplace
* [x] Bump version to `1.0.1`
* [x] Update `CHANGELOG.md`

#### Closes: https://github.com/swisstool-io/vscode-convert-to-folder/issues/9
